### PR TITLE
fix: change error detection to simply log

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 Due to the nature of the Ceramic Daemon certain files must be updated to work with your local machine. Please follow the following directions carefully to ensure functionality.
 1. On line 14 of `composedb.config.json` update the db key to be your ceramic install. You must use the full pathname as the Ceramic Daemon doesn't like relative paths. This path must start with `sqlite://` and must end with `indexing.sqlite`. Your directory should be inbetween these two required strings. EX: `sqlite:///sterahi/.ceramic/indexing.sqlite` or `sqlite:///[USERNAME]/.ceramic/indexing.sqlite` where `[USERNAME]` is your username.
 2. You must run `npm i`
-3. After the packages have been installed you must run `npm run firstTime`. This will update Ceramic packages to cooperate with AWS.
-4. You must start the server with `npm run dev` once. You may continue to use this command if you'd like however it will close all Ceramic connections at the first error. It is recommended that once your node is configured to index the required models that you run `npm run ceramic` & `npm run nextDev` separately to avoid this eager quitting.
-5. Enjoy this demo application! 
+3. You must start the server with `npm run dev` once. You may continue to use this command if you'd like however it will close all Ceramic connections at the first error. It is recommended that once your node is configured to index the required models that you run `npm run ceramic` & `npm run nextDev` separately to avoid this eager quitting.
+4. Enjoy this demo application! 
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "firstTime": "npx aws-sdk-js-codemod -t v2-to-v3 .",
     "dev": "node scripts/run.mjs",
     "nextDev": "next dev",
     "ceramic": "CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB='true' ceramic daemon --config ./composedb.config.json",

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -17,12 +17,7 @@ ceramic.stdout.on("data", (buffer) => {
 })
 
 ceramic.stderr.on('data', (err) => {
-  // TODO: figure out what causes this error in the Ceramic Daemon
-  if(!err.toString().includes('MaxListenersExceededWarning')) {
-    spinner.fail("[Ceramic] Ceramic node failed to start with error:");
-    spinner.fail(`[Ceramic] ${err.toString()}`);
-    events.emit("ceramic", false);
-  }
+  console.log(err.toString())
 })
 
 const bootstrap = async () => {
@@ -61,7 +56,7 @@ const start = async () => {
   try {
     spinner.start('[Ceramic] Starting Ceramic node\n')
     events.on('ceramic', async (isRunning) => {
-      if(isRunning) {
+      if (isRunning) {
         await bootstrap()
         await graphiql()
         await next()


### PR DESCRIPTION
Previous behavior treated any output on stderr a failure and would exit the script. This made it difficult to debug as some _warnings_ were output on stderr and trying to allow list all of them was not working.

The new behavior is that stderr is simply echoed back out to the console so errors can been observed and addressed.

As such the `firstTime` run was removed since that was intended to address the warnings but is no longer needed and did not succeed on my system anyway.